### PR TITLE
Add links to the hackathon portal

### DIFF
--- a/src/components/LandingText/index.tsx
+++ b/src/components/LandingText/index.tsx
@@ -23,15 +23,15 @@ const LandingText = ({ className = '' }: LandingTextProps) => {
       </Typography>
       <div className={styles.interestForm}>
         <Typography variant="title/small" className={styles.subtitle}>
-          Interested in joining? Fill out our interest form!
+          Interested in joining? Applications are now open!
         </Typography>
         <div className={styles.buttonContainer}>
           <Link
-            href="https://acmurl.com/hackathon-interest-form"
+            href="https://portal.diamondhacks.acmucsd.com/"
             target="_blank"
             className={styles.button}
           >
-            Notify me for updates
+            Apply Now
           </Link>
           <Link
             href="mailto:hackathon@acmucsd.org"

--- a/src/components/Navbar/index.tsx
+++ b/src/components/Navbar/index.tsx
@@ -20,6 +20,7 @@ const links: LinkMetadata[] = [
   { name: 'Impact', href: '/#impact' },
   { name: 'FAQ', href: '/#faq' },
   { name: 'Sponsors', href: '/#sponsors' },
+  { name: 'Apply', href: 'https://portal.diamondhacks.acmucsd.com' },
   { name: '2024', href: 'https://2024.diamondhacks.acmucsd.com' },
 ];
 

--- a/src/sections/FAQ/questions.tsx
+++ b/src/sections/FAQ/questions.tsx
@@ -11,11 +11,9 @@ export const QUESTIONS: Question[] = [
     question: 'How can I register for DiamondHacks?',
     answer: (
       <>
-        Fill out the interest form here (
-        <Link href="https://acmurl.com/diamondhacks-interest-form">
-          https://acmurl.com/diamondhacks-interest-form
-        </Link>
-        ) to be notified when applications go live!
+        Create an account and submit your application on the{' '}
+        <Link href="https://portal.diamondhacks.acmucsd.com/">DiamondHacks Portal</Link> by February
+        28, 2025!
       </>
     ),
   },


### PR DESCRIPTION
<!-- Fill in all spots surrounded by brackets and confirm all check boxes after confirming completion of the tasks -->

# Info

Closes #22 

<!-- If there is no issue for this pull request yet, please create one or
delete this line if the pull request is for a very minor tweak. -->

Replaced references to the interest form with links to the hackathon portal. Feedback on copywriting would be appreciated

<!-- What changes did you make? List all distinct problems that this PR addresses. Explain any relevant
motivation or context. -->

## Changes

- Changed hero text to link to portal
- Added "Apply" link to navbar
- FAQ now links to portal instead of interest form

# Type of Change

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Logistics Change (A change to a README, description, or dev workflow setup like
      linting/formatting)
- [ ] Continuous Integration Change (Related to deployment steps or continuous integration
      workflows)
- [ ] Other: (Fill In) <!-- Edit this type of change if you select this -->

# Testing

I have tested that my changes fully resolve the linked issue ...

- [x] locally on Desktop.
- [ ] on the live deployment preview on Desktop.
- [ ] on the live deployment preview on Mobile.
- [ ] I have added new Cypress tests that are passing.

# Checklist

- [x] I have performed a self-review of my own code.
- [x] I have followed the style guidelines of this project.
- [x] I have documented any new functions in `/src/lib/*` and commented hard to understand areas
      anywhere else.
- [x] My changes produce no new warnings.

# Screenshots

<!-- If you made any visual changes to the website, please include relevant screenshots below. -->

![image](https://github.com/user-attachments/assets/15311bf7-c276-4f67-a21b-a5c834f40f3b)


![image](https://github.com/user-attachments/assets/e21ed95f-1ff8-4280-96a9-4197a7d67913)

